### PR TITLE
Postfix mbox check

### DIFF
--- a/lib/generic/mda.php
+++ b/lib/generic/mda.php
@@ -61,6 +61,11 @@ function receive_mail($call) {
         $raw = $call['message'];
     } elseif ($call['type'] == "EXTERNAL") {
         $raw = file_get_contents("php://stdin");
+	// postfix gives you the data in mbox format (zee https://tools.ietf.org/html/rfc4155)
+	// if the first row indicates it is a mbox style, we strip the first line
+	if(strpos($raw,'From ') === 0) {
+		$raw = preg_replace('/^.+\n/','',$raw);
+	}
     } else {
         logger(LOG_ERR, __FUNCTION__ . " was called, but was unable to determin if this was internally passed or not");
         return false;

--- a/lib/generic/mda.php
+++ b/lib/generic/mda.php
@@ -61,7 +61,7 @@ function receive_mail($call) {
         $raw = $call['message'];
     } elseif ($call['type'] == "EXTERNAL") {
         $raw = file_get_contents("php://stdin");
-	// postfix gives you the data in mbox format (zee https://tools.ietf.org/html/rfc4155)
+	// postfix gives you the data in mbox format (see https://tools.ietf.org/html/rfc4155)
 	// if the first row indicates it is a mbox style, we strip the first line
 	if(strpos($raw,'From ') === 0) {
 		$raw = preg_replace('/^.+\n/','',$raw);


### PR DESCRIPTION
As discussed on IRC:
postfix pipes its incoming mail in mbox format (rfc4155) which results in a file where the first row is not a valid rfc822 header. If the data is of type EXTERNAL and it starts with "From[space]" the first row is stripped. 