### PR TITLE
Pinned notification-mail version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
 		"abuseio/collector-snds": "1.4.*",
 		
 		"abuseio/notification-common": "1.1.*",
-		"abuseio/notification-mail": "1.2.*",
+		"abuseio/notification-mail": "1.2.1",
 		"zendframework/zend-xmlrpc": "^2.5",
 		"jeremykendall/php-domain-parser": "^3.0"
 


### PR DESCRIPTION
notification 1.2.2 and higher aren’t backwards compatible with AbuseIO
4.0.1. Pinned max version 1.2.1 in composer.json