### PR TITLE
make bounce handling somewhat more robust

### DIFF
--- a/app/Jobs/AlertAdmin.php
+++ b/app/Jobs/AlertAdmin.php
@@ -127,8 +127,14 @@ class AlertAdmin extends Job
         /*
          * Add all the skipped headers from addCustomHeader and add them using methods
          */
-        $mail->addAddress($parsedMail->getHeader('to'));
-        $mail->setFrom($parsedMail->getHeader('from'));
+        preg_match_all('/<(.+?)>/i', $parsedMail->getHeader('to'), $matches);
+        $recipients = $matches[1];
+        foreach ($recipients as $recipient) {
+            $mail->addAddress($recipient);
+        }
+        preg_match('/<(.+?)>/i', $parsedMail->getHeader('from'), $matches);
+        $from = $matches[1];
+        $mail->setFrom($from);
         $mail->Subject = !empty($parsedMail->getHeader('subject')) ? $parsedMail->getHeader('subject') : '';
         $mail->MessageDate = !empty($parsedMail->getHeader('date')) ? $parsedMail->getHeader('date') : date('D, j M Y H:i:s O');
         $mail->MessageID = !empty($parsedMail->getHeader('message-id')) ? $parsedMail->getHeader('message-id') : '';


### PR DESCRIPTION
1. Set `$mail->Host` to avoid:

    ```production.ERROR: ErrorException: stream_socket_enable_crypto(): Peer certificate CN=`fully.qualified.domain' did not match expected CN=`localhost' in /opt/abuseio/vendor/kruisdraad/phpmailer/class.smtp.php:368```

2. Preserve all "To" addresses.

~3. Use `getAddresses('to')` because PHPMailer does not like the output of `"display name" <user@example.com>' provided by php-mail-mime-parser's getHeader('to') method.~

~4. Use `getAddresses('from')` because PHPMailer does not like the output of `"display name" <user@example.com>' provided by php-mail-mime-parser's getHeader('from') method.~

~5. Upgrade php-mime-mail-parser dependency to v2.6.0 or better. The getAddresses() method was added at this revision.~