### PR TITLE
Add systemd unit files; update documentation accordingly

### DIFF
--- a/docs/common_problems.md
+++ b/docs/common_problems.md
@@ -1,8 +1,8 @@
 # Common AbuseIO problems / FAQ
 
-## 1. Supervisord services not running (properly)
+## 1. Services not running (properly)
 
-Sympthoms: 
+Symptoms: 
 
 - You will get incoming e-mails, their logged as being received but the e-mail is not processed 
 - AND/OR You are missing data from tickets you are sure have been mailed onto the system
@@ -11,18 +11,16 @@ Sympthoms:
 
 Possible cause:
 
-Supervisord services not running. Most likely after installation the supervisor was asked to start, however
+Services not running. Most likely after installation the service was asked to start, however
 because the database has not been fully installed yet the daemon did not start.
 
 Once an e-mail has been received it is put into a queue to handle and the MTA part has been completed. The MTA can 
-return an 200 OK message to the sender. If the supervisord queue daemons are not running, no jobs are picked up from
+return an 200 OK message to the sender. If the service queue daemons are not running, no jobs are picked up from
 the queue and remain there until worker process has been started.
 
 Solution:
 
-Restart the supervisord services (currently 3) or the entire supervisord daemon, which is safe to do if this is system
-is dedicated to AbuseIO. After restarting it you will see in the /var/log/abuseio/queue* files the workers to pick up
-work and start handling the data from the received e-mails.
+Restart the services (currently 3) or, if you're using supervisord, the entire supervisord daemon, which is safe to do if this is system is dedicated to AbuseIO. After restarting it you will see in the /var/log/abuseio/queue* files the workers to pick up work and start handling the data from the received e-mails.
 
 ## 2. Call to undefined function mailparse_msg_create() in ../src/Parser.php on line 128
 

--- a/extra/etc/systemd/system/abuseio_queue_collector.service
+++ b/extra/etc/systemd/system/abuseio_queue_collector.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=AbuseIO Queue Collector Service
+After=network.target
+
+[Service]
+Type=simple
+User=abuseio
+WorkingDirectory=/opt/abuseio
+ExecStart=/usr/bin/php artisan queue:work --daemon --tries=1 --sleep=3 --memory=256 --delay=0 --queue=abuseio_collector
+Restart=always
+
+[Install]
+WantedBy=mutli-user.target

--- a/extra/etc/systemd/system/abuseio_queue_email_incoming.service
+++ b/extra/etc/systemd/system/abuseio_queue_email_incoming.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=AbuseIO Incoming Email Queue Service
+After=network.target
+
+[Service]
+Type=simple
+User=abuseio
+WorkingDirectory=/opt/abuseio
+ExecStart=/usr/bin/php artisan queue:work --daemon --tries=1 --sleep=3 --memory=256 --delay=0 --queue=abuseio_email_incoming
+Restart=always
+
+[Install]
+WantedBy=mutli-user.target

--- a/extra/etc/systemd/system/abuseio_queue_email_outgoing.service
+++ b/extra/etc/systemd/system/abuseio_queue_email_outgoing.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=AbuseIO Outgoing Email Queue Service
+After=network.target
+
+[Service]
+Type=simple
+User=abuseio
+WorkingDirectory=/opt/abuseio
+ExecStart=/usr/bin/php artisan queue:work --daemon --tries=1 --sleep=3 --memory=256 --delay=0 --queue=abuseio_email_outgoing
+Restart=always
+
+[Install]
+WantedBy=mutli-user.target


### PR DESCRIPTION
There is mention in the documentation of systemd, but no unit files are provided. This commit adds those unit files to the source. It also splits up supervisord and systemd in the documentation a little to make it clear that they are interchangeable and supervisord is optional if systemd is in use. Any mention of "supervisord" in any other context is changed to "service" to reduce confusion.