### PR TITLE
Update app.php another cipher

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -118,7 +118,7 @@ return [
 
     'key' => env('APP_KEY', 'SomeRandomString'),
 
-    'cipher' => MCRYPT_RIJNDAEL_128,
+    'cipher' => 'AES-256-CBC',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
For PHP 7.1 mcrypt_get_iv_size is deprecated.
Replace chipher in config/app.php to: AES-256-CBC

After config replace run:
php artisan key:generate after

error: 
[ErrorException]                             
 Function mcrypt_get_iv_size() is deprecated