### PR TITLE
make composer.json reflect the upper requirements for php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"ext-mcrypt": "Laravel / AbuseIO requirement"
 	},
 	"require": {
-		"php": ">=5.5.9",
+		"php": ">=5.5.9,<7.2.0",
 
 		"ext-mcrypt": "*",
 		"ext-intl" : "*",


### PR DESCRIPTION
https://github.com/AbuseIO/AbuseIO/issues/312#issuecomment-459958489

> make composer.json match these requirements. Currently it says"php": ">=5.5.9". If you change this to, for example, "php": ">=5.5.9,<7.2.0",, composer will warn about the unsupported PHP 7.2. Now we have to find out after installation and debugging.