### PR TITLE
change mimetype to message/rfc822 for .eml files

### DIFF
--- a/app/Jobs/AlertAdmin.php
+++ b/app/Jobs/AlertAdmin.php
@@ -32,8 +32,9 @@ class AlertAdmin extends Job
 
                 foreach ($attachments as $attachmentName => $attachmentData) {
                     $mimetype = 'text/plain';
-                    if (substr($attachmentName, -4) === '.eml')
+                    if (substr($attachmentName, -4) === '.eml') {
                         $mimetype = 'message/rfc822';
+                    }
 
                     $mail->attachData(
                         $attachmentData,

--- a/app/Jobs/AlertAdmin.php
+++ b/app/Jobs/AlertAdmin.php
@@ -31,12 +31,16 @@ class AlertAdmin extends Job
                 $mail->subject('Exception notification');
 
                 foreach ($attachments as $attachmentName => $attachmentData) {
+                    $mimetype = 'text/plain';
+                    if (substr($attachmentName, -4) === '.eml')
+                        $mimetype = 'message/rfc822';
+
                     $mail->attachData(
                         $attachmentData,
                         $attachmentName,
                         [
                             'as'   => $attachmentName,
-                            'mime' => 'text/plain',
+                            'mime' => $mimetype,
                         ]
                     );
                 }


### PR DESCRIPTION
Sets content-type to 'message/rfc822' for "failed to parse" forwarded emails. This way 'sane' mail clients can deal with the attached mesasge more easily.

[x] Tested