### PR TITLE
laravel scheduler fix, for newer cron-expression

### DIFF
--- a/config/main.php
+++ b/config/main.php
@@ -52,10 +52,10 @@ return [
         'tickets_close_after'             => '14 days',
         'closed_tickets_remove_after'     => false,
         'closed_tickets_remove_permanent' => false,
-        'notifications_cron'              => '*/15 * * * * *',
-        'collectors_cron'                 => '*/60 * * * * *',
-        'housekeeper_cron'                => '*/1 * * * * *',
-        'collect_statistics_cron'         => '0 2 * * * *', //needs some discussion on when to run;
+        'notifications_cron'              => '*/15 * * * *',
+        'collectors_cron'                 => '*/60 * * * *',
+        'housekeeper_cron'                => '*/1 * * * *',
+        'collect_statistics_cron'         => '0 2 * * *', //needs some discussion on when to run;
         'enable_queue_problem_alerts'     => true,
     ],
 


### PR DESCRIPTION
Adopt to a modern version of cron-expression, which is stricter.
(See https://github.com/dragonmantank/cron-expression/issues/29)

The issue was found while debugging dockerized AbuseIO 4.2 together with @imme-emosol 

(I've verified that the stricter format also is compatible with an older AbuseIO 4.1.0 running on Ubuntu 16.04 + PHP 7.0)