### PR TITLE
Fix incorrect model search for Role commands

### DIFF
--- a/app/Console/Commands/Role/AssignCommand.php
+++ b/app/Console/Commands/Role/AssignCommand.php
@@ -70,6 +70,12 @@ class AssignCommand extends Command
             if (!is_object($role)) {
                 $role = Role::find($this->option('role'));
             }
+
+            if (!is_object($role)) {
+                $this->error('Unable to find role with this criteria');
+
+                return false;
+            }
         }
 
         if (!empty($this->option('user'))) {
@@ -78,14 +84,14 @@ class AssignCommand extends Command
             }
 
             if (!is_object($user)) {
-                $user = Role::find($this->option('user'));
+                $user = User::find($this->option('user'));
             }
-        }
 
-        if (!is_object($role) || !is_object($user)) {
-            $this->error('Unable to find role with this criteria');
+            if (!is_object($user)) {
+                $this->error('Unable to find user with this criteria');
 
-            return false;
+                return false;
+            }
         }
 
         $RoleUser = new RoleUser();

--- a/app/Console/Commands/Role/RevokeCommand.php
+++ b/app/Console/Commands/Role/RevokeCommand.php
@@ -66,6 +66,12 @@ class RevokeCommand extends Command
             if (!is_object($role)) {
                 $role = Role::find($this->option('role'));
             }
+
+            if (!is_object($role)) {
+                $this->error('Unable to find role with this criteria');
+
+                return false;
+            }
         }
 
         if (!empty($this->option('user'))) {
@@ -74,14 +80,14 @@ class RevokeCommand extends Command
             }
 
             if (!is_object($user)) {
-                $user = Role::find($this->option('user'));
+                $user = User::find($this->option('user'));
             }
-        }
 
-        if (!is_object($role) || !is_object($user)) {
-            $this->error('Unable to find role with this criteria');
+            if (!is_object($user)) {
+                $this->error('Unable to find user with this criteria');
 
-            return false;
+                return false;
+            }
         }
 
         $roleUser = RoleUser::all()

--- a/app/Console/Commands/Role/RevokeCommand.php
+++ b/app/Console/Commands/Role/RevokeCommand.php
@@ -109,7 +109,7 @@ class RevokeCommand extends Command
             return false;
         }
 
-        $this->info("The role {$role->name} has been revoked from role {$user->email}");
+        $this->info("The role {$role->name} has been revoked from user {$user->email}");
 
         return true;
     }


### PR DESCRIPTION
The `role:assign` and `role:revoke` commands look up the user by `email` correctly, but the lookup by `id` fails. This is because it's the `Role::find()` method to search for the user, which should be the `User::find()` method.

This PR switches those to use `User:find()` instead, and splits the error to be missing role and missing user specific