### PR TITLE
multiple api fixes

### DIFF
--- a/app/Http/Controllers/NetblocksController.php
+++ b/app/Http/Controllers/NetblocksController.php
@@ -57,7 +57,7 @@ class NetblocksController extends Controller
                     ->where('enabled', '=', true)
                     ->orderBy('first_ip_int', 'desc')
                     ->orderBy('last_ip_int', 'asc')
-                    ->take(1);
+                    ->take(1)->get();
                 break;
 
             // Fail unknown method

--- a/app/Http/Middleware/CheckAccount.php
+++ b/app/Http/Middleware/CheckAccount.php
@@ -82,7 +82,7 @@ class CheckAccount
      */
     private function getAccount()
     {
-        return property_exists($this->request, 'api_account') ?
+        return isset($this->request->api_account) ?
             $this->request->api_account : Auth::user()->account;
     }
 
@@ -92,7 +92,7 @@ class CheckAccount
     private function resolveModelId($request)
     {
         // use the correct segment
-        if (property_exists($request, 'api_account')) {
+        if (isset($request->api_account)) {
             $model_id = $request->segment(self::API_ID_SEGMENT);
         } else {
             $model_id = $request->segment(self::WEB_ID_SEGMENT);

--- a/app/Http/Requests/AccountFormRequest.php
+++ b/app/Http/Requests/AccountFormRequest.php
@@ -37,6 +37,7 @@ class AccountFormRequest extends Request
             case 'POST':
                 return Account::createRules();
             case 'PUT':
+                break;
             case 'PATCH':
                 return Account::updateRules($this);
             default:

--- a/app/Http/Requests/ContactFormRequest.php
+++ b/app/Http/Requests/ContactFormRequest.php
@@ -46,6 +46,7 @@ class ContactFormRequest extends Request
             case 'POST':
                 return Contact::createRules();
             case 'PUT':
+                break;
             case 'PATCH':
                 return Contact::updateRules($this);
             default:

--- a/app/Http/Requests/DomainFormRequest.php
+++ b/app/Http/Requests/DomainFormRequest.php
@@ -37,6 +37,7 @@ class DomainFormRequest extends Request
             case 'POST':
                 return Domain::createRules();
             case 'PUT':
+                break;
             case 'PATCH':
                 return Domain::updateRules($this);
             default:

--- a/app/Http/Requests/NetblockFormRequest.php
+++ b/app/Http/Requests/NetblockFormRequest.php
@@ -31,10 +31,13 @@ class NetblockFormRequest extends Request
     {
         switch ($this->method()) {
             case 'GET':
+                break;
             case 'DELETE':
+                break;
             case 'POST':
                 return Netblock::createRules($this);
             case 'PUT':
+                break;
             case 'PATCH':
                 return Netblock::updateRules($this);
             default:

--- a/app/Http/Requests/NoteFormRequest.php
+++ b/app/Http/Requests/NoteFormRequest.php
@@ -37,6 +37,7 @@ class NoteFormRequest extends Request
             case 'POST':
                 return Note::createRules();
             case 'PUT':
+                break;
             case 'PATCH':
                 return Note::updateRules();
             default:

--- a/app/Http/Requests/TicketFormRequest.php
+++ b/app/Http/Requests/TicketFormRequest.php
@@ -38,6 +38,7 @@ class TicketFormRequest extends Request
                 return Ticket::createRules();
                 break;
             case 'PUT':
+                break;
             case 'PATCH':
                 return Ticket::updateRules($this);
                 break;

--- a/app/Transformers/NetblockTransformer.php
+++ b/app/Transformers/NetblockTransformer.php
@@ -17,6 +17,7 @@ class NetblockTransformer extends TransformerAbstract
     public function transform(Netblock $netblock)
     {
         return [
+            'id'          => (int) $netblock->id,
             'first_ip'    => (string) $netblock->first_ip,
             'last_ip'     => (string) $netblock->last_ip,
             'description' => (string) $netblock->description,


### PR DESCRIPTION
A bunch of fixes to make the API functional again.

We got the following 
- [X] missing get in the NetblocksController@apiSearch() filter.

Here is what search by id looks like and what it returns:
```
>>> Netblock::withTrashed()->where('id', '=', 1)->get();
=> Illuminate\Database\Eloquent\Collection {#4838
     all: [
       AbuseIO\Models\Netblock {#4839
         id: 1,
         contact_id: 1,
         first_ip: "10.20.30.1",
         first_ip_int: "169090561",
         last_ip: "10.20.30.255",
         last_ip_int: "169090815",
         description: "TEST_NET",
         enabled: 1,
         created_at: "2022-01-04 09:55:37",
         updated_at: "2022-02-01 00:42:45",
         deleted_at: null,
       },
     ],
   }
```

The search by address query isn't executed correctly, so only the Eloquent query object is returned.

```
>>> $ip = "10.20.30.1";
=> "10.20.30.1"
>>> Netblock::where('first_ip_int', '<=', inetPtoi($ip))->where('last_ip_int', '>=', inetPtoi($ip))->where('enabled', '=', true)->orderBy('first_ip_int', 'desc')->orderBy('last_ip_int', 'asc')->take(1);
=> Illuminate\Database\Eloquent\Builder {#4836}
```

Instead, we should be doing this:
```
>>> Netblock::where('first_ip_int', '<=', inetPtoi($ip))->where('last_ip_int', '>=', inetPtoi($ip))->where('enabled', '=', true)->orderBy('first_ip_int', 'desc')->orderBy('last_ip_int', 'asc')->take(1)->get();
=> Illuminate\Database\Eloquent\Collection {#4853
     all: [
       AbuseIO\Models\Netblock {#4852
         id: 1,
         contact_id: 1,
         first_ip: "10.20.30.1",
         first_ip_int: "169090561",
         last_ip: "10.20.30.255",
         last_ip_int: "169090815",
         description: "TEST_NET",
         enabled: 1,
         created_at: "2022-01-04 09:55:37",
         updated_at: "2022-02-01 00:42:45",
         deleted_at: null,
       },
     ],
   }
```
- [X]  `property_exists($request, 'api_account')` always returns null, because `api_account` isn't a real property, but an Eloquent dynamic property. Now, `isset()` appears to work properly with these.

- [X] Several breaks in case statements are missing inside FormRequests which cause unexpected errors. 

- [X] The `id` is now exposed for Netblocks so that it could be referenced in subsequent queries.

Lastly, please note that the `X-Requested-With: XMLHttpRequest` header needs to be set with your API request for Laravel to route them correctly. Without that, you will get the same behaviour as shown in #345 

```
curl -X PUT -H "X-Requested-With: XMLHttpRequest" -H "Content-Type: application/json" \ 
-H "X-API-TOKEN: REDACTED" --data "@update.json" http://abuseio.local/api/v1/netblocks/1
```

I might have missed something, and I will be upfront that I only tested a limited number of calls to Contact and Netblock controllers as these are of interest to me.

But feel free to let me know if anything else doesn't work, and I will check.
