### PR TITLE
Add support for configuration options through environment variables

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -67,7 +67,7 @@ return [
     |
     */
 
-    'timezone'    => 'UTC',
+    'timezone' => env('APP_TIMEZONE', 'UTC'),
 
     /*
     |--------------------------------------------------------------------------
@@ -79,9 +79,10 @@ return [
     */
 
     // Implement ISO 8601 usage
-    'date_format' => 'c',
+    // 'date_format' => 'c',
     // or use this for more human readable:
     // 'date_format' => 'd-m-Y H:i:s P',
+    'date_format' => env('APP_DATE_FORMAT', 'c'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/mail.php
+++ b/config/mail.php
@@ -148,9 +148,9 @@ return [
     |
     */
     'smime' => [
-        'enabled'     => false,
-        'key'         => '/opt/abuseio/config/smikme/key.pem',
-        'certificate' => '/opt/abuseio/config/smikme/certificate.pem',
+        'enabled'     => env('MAIL_SMIME_ENABLED', false),
+        'key'         => env('MAIL_SMIME_KEY', '/opt/abuseio/config/smikme/key.pem'),
+        'certificate' => env('MAIL_SMIME_CERTIFICATE', '/opt/abuseio/config/smikme/certificate.pem'),
     ],
 
     /*

--- a/config/main.php
+++ b/config/main.php
@@ -25,8 +25,8 @@ return [
     ],
 
     'reports' => [
-        'min_lastseen'    => false, //This ignores any event older then threshold
-        'resolvable_only' => false, // This drops anything if a domain or netblock cannot be found
+        'min_lastseen'    => env('MAIN_REPORTS_MIN_LASTSEEN', false), //This ignores any event older then threshold
+        'resolvable_only' => env('MAIN_REPORTS_RESOLVABLE_ONLY', false), // This drops anything if a domain or netblock cannot be found
     ],
 
     'notes' => [

--- a/config/main.php
+++ b/config/main.php
@@ -13,9 +13,9 @@ return [
     ],
 
     'emailparser' => [
-        'fallback_mail'      => 'admin@isp.local',
-        'use_bounce_method'  => false,
-        'notify_on_warnings' => true,
+        'fallback_mail'      => env('MAIN_EMAILPARSER_FALLBACK_MAIL', 'admin@isp.local'),
+        'use_bounce_method'  => env('MAIN_EMAILPARSER_USE_BOUNCE_METHOD', false),
+        'notify_on_warnings' => env('MAIN_EMAILPARSER_NOTIFY_ON_WARNINGS', true),
     ],
 
     // A list of installation UUID's which are considered to be parents allowing them to push events thru the API

--- a/config/main.php
+++ b/config/main.php
@@ -36,14 +36,14 @@ return [
     ],
 
     'notifications' => [
-        'enabled'        => true,
-        'info_interval'  => '90 days',
-        'abuse_interval' => '0 minutes',
-        'min_lastseen'   => '14 days',
-        'from_address'   => 'abuse@isp.local',
-        'from_name'      => 'ISP Abusedesk',
-        'bcc_enabled'    => false,
-        'bcc_address'    => 'management@isp.local',
+        'enabled'        => env('MAIN_NOTIFICATIONS_ENABLED', true),
+        'info_interval'  => env('MAIN_NOTIFICATIONS_INFO_INTERVAL', '90 days'),
+        'abuse_interval' => env('MAIN_NOTIFICATIONS_ABUSE_INTERVAL', '0 minutes'),
+        'min_lastseen'   => env('MAIN_NOTIFICATIONS_MIN_LASTSEEN', '14 days'),
+        'from_address'   => env('MAIN_NOTIFICATIONS_FROM_ADDRESS', 'abuse@isp.local'),
+        'from_name'      => env('MAIN_NOTIFICATIONS_FROM_NAME', 'ISP Abusedesk'),
+        'bcc_enabled'    => env('MAIN_NOTIFICATIONS_BCC_ENABLED', false),
+        'bcc_address'    => env('MAIN_NOTIFICATIONS_BCC_ADDRESS', 'management@isp.local'),
     ],
 
     'housekeeping' => [


### PR DESCRIPTION
It would be useful to allow setting some configuration options through environment variables, instead of requiring to change the respective values directly through the source code. All current changes simply allow setting the respective options through environment variables, but keep the default options intact for compatibility purposes.