### PR TITLE
Fix hydrate Exception object given instead of array

### DIFF
--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -149,7 +149,7 @@ class Account extends Model
             ->leftJoin('roles', 'role_user.role_id', '=', 'roles.id')
             ->where('roles.name', '=', 'Admin')
             ->where('users.account_id', '=', $this->id)
-            ->select('users.*')->get();
+            ->select('users.*')->get()->toArray();
 
         return User::hydrate($admins);
     }


### PR DESCRIPTION
Hello,

A POST call on Incidents API endpoint thrown the following exception : 
`[2023-04-12 12:23:01] production.ERROR: Argument 1 passed to Illuminate\Database\Eloquent\Builder::hydrate() must be of the type array, object given, called in /opt/abuseio/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php on line 23 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Argument 1 passed to Illuminate\\Database\\Eloquent\\Builder::hydrate() must be of the type array, object given, called in /opt/abuseio/vendor/laravel/framework/src/Illuminate/Support/Traits/ForwardsCalls.php on line 23 at /opt/abuseio/vendor/laravel/framework/src/Illuminate/Database/Eloquent/Builder.php:318)`

This is related to Builder call on admins function on Models/Account. The builder return an object instead of array needed by the hydrate function.

PR to fix them.

Regards
Gaëtan