### PR TITLE
Fix target='_blank', remove a link in EN and GR

### DIFF
--- a/resources/lang/en/classifications.php
+++ b/resources/lang/en/classifications.php
@@ -207,8 +207,8 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://www.bsi.bund.de/EN/Themen/Verbraucherinnen-und-Verbraucher/Cyber-Sicherheitslage/Methoden-der-Cyber-Kriminalitaet/Botnetze/botnet_node.html'>Botnets - consequences and protective actions</a><br>
-            <a target'_blank' href='https://www.bsi.bund.de/EN/Themen/Verbraucherinnen-und-Verbraucher/Informationen-und-Empfehlungen/Cyber-Sicherheitsempfehlungen/Infizierte-Systeme-bereinigen/infizierte-systeme-bereinigen_node.html'>Cleaning up infected systems</a><br>
+            <a target='_blank' href='https://www.bsi.bund.de/EN/Themen/Verbraucherinnen-und-Verbraucher/Cyber-Sicherheitslage/Methoden-der-Cyber-Kriminalitaet/Botnetze/botnet_node.html'>Botnets - consequences and protective actions</a><br>
+            <a target='_blank' href='https://www.bsi.bund.de/EN/Themen/Verbraucherinnen-und-Verbraucher/Informationen-und-Empfehlungen/Cyber-Sicherheitsempfehlungen/Infizierte-Systeme-bereinigen/infizierte-systeme-bereinigen_node.html'>Cleaning up infected systems</a><br>
 
             ",
     ],
@@ -302,7 +302,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://web.dev/articles/hacked'>Google's help for webmasters of hacked websites</a><br>
+            <a target='_blank' href='https://web.dev/articles/hacked'>Google's help for webmasters of hacked websites</a><br>
 
             ",
     ],
@@ -335,7 +335,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://developers.google.com/search/blog/2007/08/malware-reviews-via-webmaster-tools'>Google Webmaster tools for infected sites</a><br>
+            <a target='_blank' href='https://developers.google.com/search/blog/2007/08/malware-reviews-via-webmaster-tools'>Google Webmaster tools for infected sites</a><br>
 
             ",
     ],
@@ -459,10 +459,10 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://freakattack.com/'>Tracking the FREAK Attack</a><br>
-            <a target'_blank' href='https://www.ssllabs.com/ssltest/'>SSL Server Testtool.</a><br>
-            <a target'_blank' href='https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations'>Mozilla’s security configuration guide</a><br>
-            <a target'_blank' href='https://ssl-config.mozilla.org/'>SSL Configuration Generator</a><br>
+            <a target='_blank' href='https://freakattack.com/'>Tracking the FREAK Attack</a><br>
+            <a target='_blank' href='https://www.ssllabs.com/ssltest/'>SSL Server Testtool.</a><br>
+            <a target='_blank' href='https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations'>Mozilla’s security configuration guide</a><br>
+            <a target='_blank' href='https://ssl-config.mozilla.org/'>SSL Configuration Generator</a><br>
             ",
     ],
 
@@ -562,7 +562,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://dnsamplificationattacks.blogspot.nl/2013/07/source-port-chargen-destination-port.html'>Amplification Attacks Observer</a><br>
+            <a target='_blank' href='https://dnsamplificationattacks.blogspot.nl/2013/07/source-port-chargen-destination-port.html'>Amplification Attacks Observer</a><br>
             ",
     ],
 
@@ -666,17 +666,17 @@ return [
 
             <p>Please see the following Microsoft TechNet examples:<br>
             <br>
-            <a target'_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc771738(v=ws.11)'>Disabling recursion on Windows Server 2008 R2 systems</a><br>
-            <a target'_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc787602(v=ws.10)'>Disabling recursion on older Windows Server systems</a><br>
-            <a target'_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc773370(v=ws.10)'>Acting as a non-recursive forwarder</a> (See the 'Notes' section under the 'Using the Windows interface' instructions)<br>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc771738(v=ws.11)'>Disabling recursion on Windows Server 2008 R2 systems</a><br>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc787602(v=ws.10)'>Disabling recursion on older Windows Server systems</a><br>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc773370(v=ws.10)'>Acting as a non-recursive forwarder</a> (See the 'Notes' section under the 'Using the Windows interface' instructions)<br>
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://www.cisa.gov/sites/default/files/publications/DNS-recursion033006.pdf'>The Continuing Denial of Service Threat Posed by DNS Recursion (v2.0)</a><br>
-            <a target'_blank' href='https://www.cymru.com/Documents/secure-bind-template.html'>http://www.cymru.com/Documents/secure-bind-template.html</a><br>
-            <a target'_blank' href='https://itp.cdn.icann.org/en/files/security-and-stability-advisory-committee-ssac-reports/dns-ddos-advisory-31mar06-en.pdf'>SSAC Advisory SAC008 DNS Distributed Denial of Service (DDoS) Attacks</a><br>
-            <a target'_blank' href='https://www.secureworks.com/research/dns-amplification'>DNS Amplification Variation Used in Recent DDoS Attacks</a><br>
-            <a target'_blank' href='https://itp.cdn.icann.org/en/files/security-and-stability-advisory-committee-ssac-reports/sac-065-en.pdf'>SSAC Advisory on DDoS Attacks Leveraging DNS Infrastructure</a><br>
+            <a target='_blank' href='https://www.cisa.gov/sites/default/files/publications/DNS-recursion033006.pdf'>The Continuing Denial of Service Threat Posed by DNS Recursion (v2.0)</a><br>
+            <a target='_blank' href='https://www.cymru.com/Documents/secure-bind-template.html'>http://www.cymru.com/Documents/secure-bind-template.html</a><br>
+            <a target='_blank' href='https://itp.cdn.icann.org/en/files/security-and-stability-advisory-committee-ssac-reports/dns-ddos-advisory-31mar06-en.pdf'>SSAC Advisory SAC008 DNS Distributed Denial of Service (DDoS) Attacks</a><br>
+            <a target='_blank' href='https://www.secureworks.com/research/dns-amplification'>DNS Amplification Variation Used in Recent DDoS Attacks</a><br>
+            <a target='_blank' href='https://itp.cdn.icann.org/en/files/security-and-stability-advisory-committee-ssac-reports/sac-065-en.pdf'>SSAC Advisory on DDoS Attacks Leveraging DNS Infrastructure</a><br>
 
             ",
     ],
@@ -783,8 +783,8 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='http://fish2.com/ipmi/'>Dan Farmer on IPMI security issues</a><br>
-            <a target'_blank' href='https://www.cisa.gov/news-events/alerts/2013/07/26/risks-using-intelligent-platform-management-interface-ipmi'>US-CERT alert TA13-207A</a><br>
+            <a target='_blank' href='http://fish2.com/ipmi/'>Dan Farmer on IPMI security issues</a><br>
+            <a target='_blank' href='https://www.cisa.gov/news-events/alerts/2013/07/26/risks-using-intelligent-platform-management-interface-ipmi'>US-CERT alert TA13-207A</a><br>
 
             ",
     ],
@@ -928,7 +928,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/configure-a-windows-firewall-for-database-engine-access?view=sql-server-ver16'>Configure a Windows Firewall for Database Engine Access</a><br>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/configure-a-windows-firewall-for-database-engine-access?view=sql-server-ver16'>Configure a Windows Firewall for Database Engine Access</a><br>
 
             ",
     ],
@@ -993,7 +993,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://www.mongodb.com/resources/products/capabilities/best-practices'>7 Best Practices For MongoDB Security (2020)</a><br>
+            <a target='_blank' href='https://www.mongodb.com/resources/products/capabilities/best-practices'>7 Best Practices For MongoDB Security (2020)</a><br>
 
             ",
     ],
@@ -1045,8 +1045,8 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://www.kb.cert.org/vuls/id/184540'>Incorrect implementation of NAT-PMP in multiple devices</a><br>
-            <a target'_blank' href='https://www.rapid7.com/blog/post/2014/10/21/r7-2014-17-nat-pmp-implementation-and-configuration-vulnerabilities/'>NAT-PMP Implementation and Configuration Vulnerabilities</a>
+            <a target='_blank' href='https://www.kb.cert.org/vuls/id/184540'>Incorrect implementation of NAT-PMP in multiple devices</a><br>
+            <a target='_blank' href='https://www.rapid7.com/blog/post/2014/10/21/r7-2014-17-nat-pmp-implementation-and-configuration-vulnerabilities/'>NAT-PMP Implementation and Configuration Vulnerabilities</a>
 
 
             ",
@@ -1142,8 +1142,8 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://github.com/team-cymru/network-security-templates/tree/master/Secure-NTP-Templates'>Examples in securing a NTP service</a>
-            <a target'_blank' href='https://christian-rossow.de/publications/amplification-ndss2014.pdf'>Amplification Hell: Revisiting Network Protocols for DDoS Abuse</a>
+            <a target='_blank' href='https://github.com/team-cymru/network-security-templates/tree/master/Secure-NTP-Templates'>Examples in securing a NTP service</a>
+            <a target='_blank' href='https://christian-rossow.de/publications/amplification-ndss2014.pdf'>Amplification Hell: Revisiting Network Protocols for DDoS Abuse</a>
 
             ",
     ],
@@ -1225,7 +1225,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-2000-server/cc940063(v=technet.10)'>Microsoft NetBIOS Over TCP/IP guide</a>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-2000-server/cc940063(v=technet.10)'>Microsoft NetBIOS Over TCP/IP guide</a>
 
             ",
     ],
@@ -1386,7 +1386,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://redis.io/docs/latest/operate/oss_and_stack/management/security/'>Redis Security advisory</a><br>
+            <a target='_blank' href='https://redis.io/docs/latest/operate/oss_and_stack/management/security/'>Redis Security advisory</a><br>
 
             ",
     ],
@@ -1637,8 +1637,8 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://web.dev/articles/hacked'>Google's help for webmasters of hacked websites</a><br>
-            <a target'_blank' href='https://www.antiphishing.org/'>The site antiphishing.org has recommendations on dealing with hacked sites.</a><br>
+            <a target='_blank' href='https://web.dev/articles/hacked'>Google's help for webmasters of hacked websites</a><br>
+            <a target='_blank' href='https://www.antiphishing.org/'>The site antiphishing.org has recommendations on dealing with hacked sites.</a><br>
 
             ",
     ],
@@ -1687,7 +1687,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='http://www.anti-abuse.org/multi-rbl-check'>Anti-abuse multi-rbl-check</a><br>
+            <a target='_blank' href='http://www.anti-abuse.org/multi-rbl-check'>Anti-abuse multi-rbl-check</a><br>
 
             ",
     ],
@@ -1783,7 +1783,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://www.techtarget.com/searchsecurity/definition/spam-trap'>What is a spam trap and how do you avoid them?</a><br>
+            <a target='_blank' href='https://www.techtarget.com/searchsecurity/definition/spam-trap'>What is a spam trap and how do you avoid them?</a><br>
 
             ",
     ],
@@ -1865,7 +1865,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://disablesslv3.com/'>Disable SSLv3 - a community-powered step-by-step tutorial</a><br>
+            <a target='_blank' href='https://disablesslv3.com/'>Disable SSLv3 - a community-powered step-by-step tutorial</a><br>
 
             ",
     ],
@@ -1897,7 +1897,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://wordpress.org/plugins/sucuri-scanner/'>WordPress Security scanner (Sucuri)</a><br>
+            <a target='_blank' href='https://wordpress.org/plugins/sucuri-scanner/'>WordPress Security scanner (Sucuri)</a><br>
 
             ",
     ],

--- a/resources/lang/en/classifications.php
+++ b/resources/lang/en/classifications.php
@@ -2147,8 +2147,7 @@ return [
             of these attacks is spoofed to the victim address, it is only possible to report on victims being abused, not on the true 
             source of the DDoS.</p>
             
-            <p>You can read more about our DDoS attack observations <a target='_blank' href='https://sissden.eu/blog/amp2018'>in the SISSDEN blog 
-            entry on observations on DDoS attacks in 2018</a>. For more insight into how amplifiable DDoS attacks work, check out this 
+            <p>For more insight into how amplifiable DDoS attacks work, check out this 
             <a target='_blank' href='https://christian-rossow.de/articles/Amplification_DDoS.php'>writeup and paper by Christian Rossow</a>,&nbsp;as 
             well as the <a target='_blank' href='https://www.us-cert.gov/ncas/alerts/TA14-017A'>US-CERT Alert (TA14-017A)</a>.</p>
             

--- a/resources/lang/en/classifications.php
+++ b/resources/lang/en/classifications.php
@@ -99,7 +99,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target\'_blank\' href=\'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20160916-ikev1\'>IKEv1 Information Disclosure Vulnerability in Multiple Cisco Products</a><br>
+            <a target=\'_blank\' href=\'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20160916-ikev1\'>IKEv1 Information Disclosure Vulnerability in Multiple Cisco Products</a><br>
 
             ',
     ],
@@ -132,7 +132,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target\'_blank\' href=\'https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc743162(v=ws.11)\'>Remote Desktop Services and Windows Firewall</a><br>
+            <a target=\'_blank\' href=\'https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc743162(v=ws.11)\'>Remote Desktop Services and Windows Firewall</a><br>
             ',
     ],
 
@@ -1934,7 +1934,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a href='https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-cluster.html#preventing-unauthorized-access'>Secure the Elastic Stack</a><br>
+            <a target='_blank' href='https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-cluster.html#preventing-unauthorized-access'>Secure the Elastic Stack</a><br>
             ",
     ],
 
@@ -2147,10 +2147,10 @@ return [
             of these attacks is spoofed to the victim address, it is only possible to report on victims being abused, not on the true 
             source of the DDoS.</p>
             
-            <p>You can read more about our DDoS attack observations <a href='https://sissden.eu/blog/amp2018'>in the SISSDEN blog 
+            <p>You can read more about our DDoS attack observations <a target='_blank' href='https://sissden.eu/blog/amp2018'>in the SISSDEN blog 
             entry on observations on DDoS attacks in 2018</a>. For more insight into how amplifiable DDoS attacks work, check out this 
-            <a href='https://christian-rossow.de/articles/Amplification_DDoS.php'>writeup and paper by Christian Rossow</a>,&nbsp;as 
-            well as the <a href='https://www.us-cert.gov/ncas/alerts/TA14-017A'>US-CERT Alert (TA14-017A)</a>.</p>
+            <a target='_blank' href='https://christian-rossow.de/articles/Amplification_DDoS.php'>writeup and paper by Christian Rossow</a>,&nbsp;as 
+            well as the <a target='_blank' href='https://www.us-cert.gov/ncas/alerts/TA14-017A'>US-CERT Alert (TA14-017A)</a>.</p>
             
             <p>This report contains information about the IP that was attacked (set to src_ip) and the port that was abused on the 
             honeypot to try to make it attack your IP (set to dst_port).</p>

--- a/resources/lang/gr/classifications.php
+++ b/resources/lang/gr/classifications.php
@@ -2150,8 +2150,7 @@ return [
             of these attacks is spoofed to the victim address, it is only possible to report on victims being abused, not on the true 
             source of the DDoS.</p>
             
-            <p>You can read more about our DDoS attack observations <a target='_blank' href='https://sissden.eu/blog/amp2018'>in the SISSDEN blog 
-            entry on observations on DDoS attacks in 2018</a>. For more insight into how amplifiable DDoS attacks work, check out this 
+            <p>For more insight into how amplifiable DDoS attacks work, check out this 
             <a target='_blank' href='https://christian-rossow.de/articles/Amplification_DDoS.php'>writeup and paper by Christian Rossow</a>,&nbsp;as 
             well as the <a target='_blank' href='https://www.us-cert.gov/ncas/alerts/TA14-017A'>US-CERT Alert (TA14-017A)</a>.</p>
             

--- a/resources/lang/gr/classifications.php
+++ b/resources/lang/gr/classifications.php
@@ -2150,7 +2150,7 @@ return [
             of these attacks is spoofed to the victim address, it is only possible to report on victims being abused, not on the true 
             source of the DDoS.</p>
             
-            <p>You can read more about our DDoS attack observations <a href='https://sissden.eu/blog/amp2018'>in the SISSDEN blog 
+            <p>You can read more about our DDoS attack observations <a target='_blank' href='https://sissden.eu/blog/amp2018'>in the SISSDEN blog 
             entry on observations on DDoS attacks in 2018</a>. For more insight into how amplifiable DDoS attacks work, check out this 
             <a target='_blank' href='https://christian-rossow.de/articles/Amplification_DDoS.php'>writeup and paper by Christian Rossow</a>,&nbsp;as 
             well as the <a target='_blank' href='https://www.us-cert.gov/ncas/alerts/TA14-017A'>US-CERT Alert (TA14-017A)</a>.</p>

--- a/resources/lang/gr/classifications.php
+++ b/resources/lang/gr/classifications.php
@@ -208,8 +208,8 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://www.bsi.bund.de/EN/Themen/Verbraucherinnen-und-Verbraucher/Cyber-Sicherheitslage/Methoden-der-Cyber-Kriminalitaet/Botnetze/botnet_node.html'>Botnets - consequences and protective actions</a><br>
-            <a target'_blank' href='https://www.bsi.bund.de/EN/Themen/Verbraucherinnen-und-Verbraucher/Informationen-und-Empfehlungen/Cyber-Sicherheitsempfehlungen/Infizierte-Systeme-bereinigen/infizierte-systeme-bereinigen_node.html'>Cleaning up infected systems</a><br>
+            <a target='_blank' href='https://www.bsi.bund.de/EN/Themen/Verbraucherinnen-und-Verbraucher/Cyber-Sicherheitslage/Methoden-der-Cyber-Kriminalitaet/Botnetze/botnet_node.html'>Botnets - consequences and protective actions</a><br>
+            <a target='_blank' href='https://www.bsi.bund.de/EN/Themen/Verbraucherinnen-und-Verbraucher/Informationen-und-Empfehlungen/Cyber-Sicherheitsempfehlungen/Infizierte-Systeme-bereinigen/infizierte-systeme-bereinigen_node.html'>Cleaning up infected systems</a><br>
 
             ",
     ],
@@ -305,7 +305,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://web.dev/articles/hacked'>Google's help for webmasters of hacked websites</a><br>
+            <a target='_blank' href='https://web.dev/articles/hacked'>Google's help for webmasters of hacked websites</a><br>
 
             ",
     ],
@@ -338,7 +338,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://developers.google.com/search/blog/2007/08/malware-reviews-via-webmaster-tools'>Google Webmaster tools for infected sites</a><br>
+            <a target='_blank' href='https://developers.google.com/search/blog/2007/08/malware-reviews-via-webmaster-tools'>Google Webmaster tools for infected sites</a><br>
 
             ",
     ],
@@ -462,10 +462,10 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://freakattack.com/'>Tracking the FREAK Attack</a><br>
-            <a target'_blank' href='https://www.ssllabs.com/ssltest/'>SSL Server Testtool.</a><br>
-            <a target'_blank' href='https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations'>Mozilla’s security configuration guide</a><br>
-            <a target'_blank' href='https://ssl-config.mozilla.org/'>SSL Configuration Generator</a><br>
+            <a target='_blank' href='https://freakattack.com/'>Tracking the FREAK Attack</a><br>
+            <a target='_blank' href='https://www.ssllabs.com/ssltest/'>SSL Server Testtool.</a><br>
+            <a target='_blank' href='https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations'>Mozilla’s security configuration guide</a><br>
+            <a target='_blank' href='https://ssl-config.mozilla.org/'>SSL Configuration Generator</a><br>
             ",
     ],
 
@@ -565,7 +565,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://dnsamplificationattacks.blogspot.nl/2013/07/source-port-chargen-destination-port.html'>Amplification Attacks Observer</a><br>
+            <a target='_blank' href='https://dnsamplificationattacks.blogspot.nl/2013/07/source-port-chargen-destination-port.html'>Amplification Attacks Observer</a><br>
             ",
     ],
 
@@ -669,17 +669,17 @@ return [
 
             <p>Please see the following Microsoft TechNet examples:<br>
             <br>
-            <a target'_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc771738(v=ws.11)'>Disabling recursion on Windows Server 2008 R2 systems</a><br>
-            <a target'_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc787602(v=ws.10)'>Disabling recursion on older Windows Server systems</a><br>
-            <a target'_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc773370(v=ws.10)'>Acting as a non-recursive forwarder</a> (See the 'Notes' section under the 'Using the Windows interface' instructions)<br>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc771738(v=ws.11)'>Disabling recursion on Windows Server 2008 R2 systems</a><br>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc787602(v=ws.10)'>Disabling recursion on older Windows Server systems</a><br>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc773370(v=ws.10)'>Acting as a non-recursive forwarder</a> (See the 'Notes' section under the 'Using the Windows interface' instructions)<br>
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://www.cisa.gov/sites/default/files/publications/DNS-recursion033006.pdf'>The Continuing Denial of Service Threat Posed by DNS Recursion (v2.0)</a><br>
-            <a target'_blank' href='https://www.cymru.com/Documents/secure-bind-template.html'>http://www.cymru.com/Documents/secure-bind-template.html</a><br>
-            <a target'_blank' href='https://itp.cdn.icann.org/en/files/security-and-stability-advisory-committee-ssac-reports/dns-ddos-advisory-31mar06-en.pdf'>SSAC Advisory SAC008 DNS Distributed Denial of Service (DDoS) Attacks</a><br>
-            <a target'_blank' href='https://www.secureworks.com/research/dns-amplification'>DNS Amplification Variation Used in Recent DDoS Attacks</a><br>
-            <a target'_blank' href='https://itp.cdn.icann.org/en/files/security-and-stability-advisory-committee-ssac-reports/sac-065-en.pdf'>SSAC Advisory on DDoS Attacks Leveraging DNS Infrastructure</a><br>
+            <a target='_blank' href='https://www.cisa.gov/sites/default/files/publications/DNS-recursion033006.pdf'>The Continuing Denial of Service Threat Posed by DNS Recursion (v2.0)</a><br>
+            <a target='_blank' href='https://www.cymru.com/Documents/secure-bind-template.html'>http://www.cymru.com/Documents/secure-bind-template.html</a><br>
+            <a target='_blank' href='https://itp.cdn.icann.org/en/files/security-and-stability-advisory-committee-ssac-reports/dns-ddos-advisory-31mar06-en.pdf'>SSAC Advisory SAC008 DNS Distributed Denial of Service (DDoS) Attacks</a><br>
+            <a target='_blank' href='https://www.secureworks.com/research/dns-amplification'>DNS Amplification Variation Used in Recent DDoS Attacks</a><br>
+            <a target='_blank' href='https://itp.cdn.icann.org/en/files/security-and-stability-advisory-committee-ssac-reports/sac-065-en.pdf'>SSAC Advisory on DDoS Attacks Leveraging DNS Infrastructure</a><br>
 
             ",
     ],
@@ -786,8 +786,8 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='http://fish2.com/ipmi/'>Dan Farmer on IPMI security issues</a><br>
-            <a target'_blank' href='https://www.cisa.gov/news-events/alerts/2013/07/26/risks-using-intelligent-platform-management-interface-ipmi'>US-CERT alert TA13-207A</a><br>
+            <a target='_blank' href='http://fish2.com/ipmi/'>Dan Farmer on IPMI security issues</a><br>
+            <a target='_blank' href='https://www.cisa.gov/news-events/alerts/2013/07/26/risks-using-intelligent-platform-management-interface-ipmi'>US-CERT alert TA13-207A</a><br>
 
             ",
     ],
@@ -931,7 +931,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/configure-a-windows-firewall-for-database-engine-access?view=sql-server-ver16'>Configure a Windows Firewall for Database Engine Access</a><br>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/configure-a-windows-firewall-for-database-engine-access?view=sql-server-ver16'>Configure a Windows Firewall for Database Engine Access</a><br>
 
             ",
     ],
@@ -996,7 +996,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://www.mongodb.com/resources/products/capabilities/best-practices'>7 Best Practices For MongoDB Security (2020)</a><br>
+            <a target='_blank' href='https://www.mongodb.com/resources/products/capabilities/best-practices'>7 Best Practices For MongoDB Security (2020)</a><br>
 
             ",
     ],
@@ -1048,8 +1048,8 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://www.kb.cert.org/vuls/id/184540'>Incorrect implementation of NAT-PMP in multiple devices</a><br>
-            <a target'_blank' href='https://www.rapid7.com/blog/post/2014/10/21/r7-2014-17-nat-pmp-implementation-and-configuration-vulnerabilities/'>NAT-PMP Implementation and Configuration Vulnerabilities</a>
+            <a target='_blank' href='https://www.kb.cert.org/vuls/id/184540'>Incorrect implementation of NAT-PMP in multiple devices</a><br>
+            <a target='_blank' href='https://www.rapid7.com/blog/post/2014/10/21/r7-2014-17-nat-pmp-implementation-and-configuration-vulnerabilities/'>NAT-PMP Implementation and Configuration Vulnerabilities</a>
 
 
             ",
@@ -1145,8 +1145,8 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://github.com/team-cymru/network-security-templates/tree/master/Secure-NTP-Templates'>Examples in securing a NTP service</a>
-            <a target'_blank' href='https://christian-rossow.de/publications/amplification-ndss2014.pdf'>Amplification Hell: Revisiting Network Protocols for DDoS Abuse</a>
+            <a target='_blank' href='https://github.com/team-cymru/network-security-templates/tree/master/Secure-NTP-Templates'>Examples in securing a NTP service</a>
+            <a target='_blank' href='https://christian-rossow.de/publications/amplification-ndss2014.pdf'>Amplification Hell: Revisiting Network Protocols for DDoS Abuse</a>
 
             ",
     ],
@@ -1228,7 +1228,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-2000-server/cc940063(v=technet.10)'>Microsoft NetBIOS Over TCP/IP guide</a>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-2000-server/cc940063(v=technet.10)'>Microsoft NetBIOS Over TCP/IP guide</a>
 
             ",
     ],
@@ -1389,7 +1389,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://redis.io/docs/latest/operate/oss_and_stack/management/security/'>Redis Security advisory</a><br>
+            <a target='_blank' href='https://redis.io/docs/latest/operate/oss_and_stack/management/security/'>Redis Security advisory</a><br>
 
             ",
     ],
@@ -1640,8 +1640,8 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://web.dev/articles/hacked'>Google's help for webmasters of hacked websites</a><br>
-            <a target'_blank' href='https://www.antiphishing.org/'>The site antiphishing.org has recommendations on dealing with hacked sites.</a><br>
+            <a target='_blank' href='https://web.dev/articles/hacked'>Google's help for webmasters of hacked websites</a><br>
+            <a target='_blank' href='https://www.antiphishing.org/'>The site antiphishing.org has recommendations on dealing with hacked sites.</a><br>
 
             ",
     ],
@@ -1690,7 +1690,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='http://www.anti-abuse.org/multi-rbl-check'>Anti-abuse multi-rbl-check</a><br>
+            <a target='_blank' href='http://www.anti-abuse.org/multi-rbl-check'>Anti-abuse multi-rbl-check</a><br>
 
             ",
     ],
@@ -1786,7 +1786,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://www.techtarget.com/searchsecurity/definition/spam-trap'>What is a spam trap and how do you avoid them?</a><br>
+            <a target='_blank' href='https://www.techtarget.com/searchsecurity/definition/spam-trap'>What is a spam trap and how do you avoid them?</a><br>
 
             ",
     ],
@@ -1868,7 +1868,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://disablesslv3.com/'>Disable SSLv3 - a community-powered step-by-step tutorial</a><br>
+            <a target='_blank' href='https://disablesslv3.com/'>Disable SSLv3 - a community-powered step-by-step tutorial</a><br>
 
             ",
     ],
@@ -1900,7 +1900,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target'_blank' href='https://wordpress.org/plugins/sucuri-scanner/'>WordPress Security scanner (Sucuri)</a><br>
+            <a target='_blank' href='https://wordpress.org/plugins/sucuri-scanner/'>WordPress Security scanner (Sucuri)</a><br>
 
             ",
     ],

--- a/resources/lang/gr/classifications.php
+++ b/resources/lang/gr/classifications.php
@@ -99,7 +99,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target\'_blank\' href=\'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20160916-ikev1\'>IKEv1 Information Disclosure Vulnerability in Multiple Cisco Products</a><br>
+            <a target=\'_blank\' href=\'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20160916-ikev1\'>IKEv1 Information Disclosure Vulnerability in Multiple Cisco Products</a><br>
 
             ',
     ],
@@ -133,7 +133,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a target\'_blank\' href=\'https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc743162(v=ws.11)\'>Remote Desktop Services and Windows Firewall</a><br>
+            <a target=\'_blank\' href=\'https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc743162(v=ws.11)\'>Remote Desktop Services and Windows Firewall</a><br>
             ',
     ],
 
@@ -1937,7 +1937,7 @@ return [
 
             <h2>Getting more information</h2>
 
-            <a href='https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-cluster.html#preventing-unauthorized-access'>Secure the Elastic Stack</a><br>
+            <a target='_blank' href='https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-cluster.html#preventing-unauthorized-access'>Secure the Elastic Stack</a><br>
             ",
     ],
 
@@ -2152,8 +2152,8 @@ return [
             
             <p>You can read more about our DDoS attack observations <a href='https://sissden.eu/blog/amp2018'>in the SISSDEN blog 
             entry on observations on DDoS attacks in 2018</a>. For more insight into how amplifiable DDoS attacks work, check out this 
-            <a href='https://christian-rossow.de/articles/Amplification_DDoS.php'>writeup and paper by Christian Rossow</a>,&nbsp;as 
-            well as the <a href='https://www.us-cert.gov/ncas/alerts/TA14-017A'>US-CERT Alert (TA14-017A)</a>.</p>
+            <a target='_blank' href='https://christian-rossow.de/articles/Amplification_DDoS.php'>writeup and paper by Christian Rossow</a>,&nbsp;as 
+            well as the <a target='_blank' href='https://www.us-cert.gov/ncas/alerts/TA14-017A'>US-CERT Alert (TA14-017A)</a>.</p>
             
             <p>This report contains information about the IP that was attacked (set to src_ip) and the port that was abused on the 
             honeypot to try to make it attack your IP (set to dst_port).</p>

--- a/resources/lang/nl/classifications.php
+++ b/resources/lang/nl/classifications.php
@@ -83,7 +83,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target\'_blank\' href=\'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20160916-ikev1\'>IKEv1 Information Disclosure Vulnerability in Multiple Cisco Products</a><br>
+            <a target=\'_blank\' href=\'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20160916-ikev1\'>IKEv1 Information Disclosure Vulnerability in Multiple Cisco Products</a><br>
 
             ',
     ],
@@ -115,7 +115,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target\'_blank\' href=\'https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc743162(v=ws.11)\'>Remote Desktop Services and Windows Firewall</a><br>
+            <a target=\'_blank\' href=\'https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc743162(v=ws.11)\'>Remote Desktop Services and Windows Firewall</a><br>
             ',
     ],
 
@@ -182,8 +182,8 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://www.bsi.bund.de/EN/Themen/Verbraucherinnen-und-Verbraucher/Cyber-Sicherheitslage/Methoden-der-Cyber-Kriminalitaet/Botnetze/botnet_node.html'>Botnets - consequences and protective actions</a><br>
-            <a target'_blank' href='https://www.bsi.bund.de/EN/Themen/Verbraucherinnen-und-Verbraucher/Informationen-und-Empfehlungen/Cyber-Sicherheitsempfehlungen/Infizierte-Systeme-bereinigen/infizierte-systeme-bereinigen_node.html'>Cleaning up infected systems</a><br>
+            <a target='_blank' href='https://www.bsi.bund.de/EN/Themen/Verbraucherinnen-und-Verbraucher/Cyber-Sicherheitslage/Methoden-der-Cyber-Kriminalitaet/Botnetze/botnet_node.html'>Botnets - consequences and protective actions</a><br>
+            <a target='_blank' href='https://www.bsi.bund.de/EN/Themen/Verbraucherinnen-und-Verbraucher/Informationen-und-Empfehlungen/Cyber-Sicherheitsempfehlungen/Infizierte-Systeme-bereinigen/infizierte-systeme-bereinigen_node.html'>Cleaning up infected systems</a><br>
 
             ",
     ],
@@ -260,7 +260,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://web.dev/articles/hacked'>Google's tips voor webmasters van gehackte websites (Engels)</a><br>
+            <a target='_blank' href='https://web.dev/articles/hacked'>Google's tips voor webmasters van gehackte websites (Engels)</a><br>
 
             ",
     ],
@@ -293,7 +293,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://developers.google.com/search/blog/2007/08/malware-reviews-via-webmaster-tools</a><br>
+            <a target='_blank' href='https://developers.google.com/search/blog/2007/08/malware-reviews-via-webmaster-tools</a><br>
 
             ",
     ],
@@ -399,10 +399,10 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://freakattack.com/'>Tracking the FREAK Attack</a><br>
-            <a target'_blank' href='https://www.ssllabs.com/ssltest/'>SSL Server Testtool.</a><br>
-            <a target'_blank' href='https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations'>Mozilla’s security configuration guide</a><br>
-            <a target'_blank' href='https://ssl-config.mozilla.org/'>SSL Configuration Generator</a><br>
+            <a target='_blank' href='https://freakattack.com/'>Tracking the FREAK Attack</a><br>
+            <a target='_blank' href='https://www.ssllabs.com/ssltest/'>SSL Server Testtool.</a><br>
+            <a target='_blank' href='https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations'>Mozilla’s security configuration guide</a><br>
+            <a target='_blank' href='https://ssl-config.mozilla.org/'>SSL Configuration Generator</a><br>
 
             ",
     ],
@@ -480,7 +480,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://dnsamplificationattacks.blogspot.nl/2013/07/source-port-chargen-destination-port.html'>Amplification Attacks Observer</a><br>
+            <a target='_blank' href='https://dnsamplificationattacks.blogspot.nl/2013/07/source-port-chargen-destination-port.html'>Amplification Attacks Observer</a><br>
             ",
     ],
 
@@ -577,18 +577,18 @@ return [
 
             <p>Zie de volgende voorbeelden van Microsoft Learn (Engels):<br>
             <br>
-            <a target'_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc771738(v=ws.11)'>Disabling recursion on Windows Server 2008 R2 systems</a><br>
-            <a target'_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc787602(v=ws.10)'>Disabling recursion on older Windows Server systems</a><br>
-            <a target'_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc773370(v=ws.10)'>Acting as a non-recursive forwarder</a> (See the 'Notes' section under the 'Using the Windows interface' instructions)<br>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc771738(v=ws.11)'>Disabling recursion on Windows Server 2008 R2 systems</a><br>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc787602(v=ws.10)'>Disabling recursion on older Windows Server systems</a><br>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc773370(v=ws.10)'>Acting as a non-recursive forwarder</a> (See the 'Notes' section under the 'Using the Windows interface' instructions)<br>
             </p>
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://www.cisa.gov/sites/default/files/publications/DNS-recursion033006.pdf'>The Continuing Denial of Service Threat Posed by DNS Recursion (v2.0)</a><br>
-            <a target'_blank' href='https://www.cymru.com/Documents/secure-bind-template.html'>http://www.cymru.com/Documents/secure-bind-template.html</a><br>
-            <a target'_blank' href='https://itp.cdn.icann.org/en/files/security-and-stability-advisory-committee-ssac-reports/dns-ddos-advisory-31mar06-en.pdf'>SSAC Advisory SAC008 DNS Distributed Denial of Service (DDoS) Attacks</a><br>
-            <a target'_blank' href='https://www.secureworks.com/research/dns-amplification'>DNS Amplification Variation Used in Recent DDoS Attacks</a><br>
-            <a target'_blank' href='https://itp.cdn.icann.org/en/files/security-and-stability-advisory-committee-ssac-reports/sac-065-en.pdf'>SSAC Advisory on DDoS Attacks Leveraging DNS Infrastructure</a><br>
+            <a target='_blank' href='https://www.cisa.gov/sites/default/files/publications/DNS-recursion033006.pdf'>The Continuing Denial of Service Threat Posed by DNS Recursion (v2.0)</a><br>
+            <a target='_blank' href='https://www.cymru.com/Documents/secure-bind-template.html'>http://www.cymru.com/Documents/secure-bind-template.html</a><br>
+            <a target='_blank' href='https://itp.cdn.icann.org/en/files/security-and-stability-advisory-committee-ssac-reports/dns-ddos-advisory-31mar06-en.pdf'>SSAC Advisory SAC008 DNS Distributed Denial of Service (DDoS) Attacks</a><br>
+            <a target='_blank' href='https://www.secureworks.com/research/dns-amplification'>DNS Amplification Variation Used in Recent DDoS Attacks</a><br>
+            <a target='_blank' href='https://itp.cdn.icann.org/en/files/security-and-stability-advisory-committee-ssac-reports/sac-065-en.pdf'>SSAC Advisory on DDoS Attacks Leveraging DNS Infrastructure</a><br>
 
             ",
     ],
@@ -687,8 +687,8 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='http://fish2.com/ipmi/'>Dan Farmer on IPMI security issues</a><br>
-            <a target'_blank' href='https://www.cisa.gov/news-events/alerts/2013/07/26/risks-using-intelligent-platform-management-interface-ipmi'>US-CERT alert TA13-207A</a><br>
+            <a target='_blank' href='http://fish2.com/ipmi/'>Dan Farmer on IPMI security issues</a><br>
+            <a target='_blank' href='https://www.cisa.gov/news-events/alerts/2013/07/26/risks-using-intelligent-platform-management-interface-ipmi'>US-CERT alert TA13-207A</a><br>
 
             ",
     ],
@@ -826,7 +826,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/configure-a-windows-firewall-for-database-engine-access?view=sql-server-ver16'>Configure a Windows Firewall for Database Engine Access</a><br>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/configure-a-windows-firewall-for-database-engine-access?view=sql-server-ver16'>Configure a Windows Firewall for Database Engine Access</a><br>
 
             ",
     ],
@@ -891,7 +891,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://www.mongodb.com/resources/products/capabilities/best-practices'>7 Best Practices For MongoDB Security (2020)</a><br>
+            <a target='_blank' href='https://www.mongodb.com/resources/products/capabilities/best-practices'>7 Best Practices For MongoDB Security (2020)</a><br>
 
             ",
     ],
@@ -943,8 +943,8 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://www.kb.cert.org/vuls/id/184540'>Incorrect implementation of NAT-PMP in multiple devices</a><br>
-            <a target'_blank' href='https://www.rapid7.com/blog/post/2014/10/21/r7-2014-17-nat-pmp-implementation-and-configuration-vulnerabilities/'>NAT-PMP Implementation and Configuration Vulnerabilities</a>
+            <a target='_blank' href='https://www.kb.cert.org/vuls/id/184540'>Incorrect implementation of NAT-PMP in multiple devices</a><br>
+            <a target='_blank' href='https://www.rapid7.com/blog/post/2014/10/21/r7-2014-17-nat-pmp-implementation-and-configuration-vulnerabilities/'>NAT-PMP Implementation and Configuration Vulnerabilities</a>
 
             ",
     ],
@@ -1026,8 +1026,8 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://github.com/team-cymru/network-security-templates/tree/master/Secure-NTP-Templates'>Examples in securing a NTP service</a>
-            <a target'_blank' href='https://christian-rossow.de/publications/amplification-ndss2014.pdf'>Amplification Hell: Revisiting Network Protocols for DDoS Abuse</a>
+            <a target='_blank' href='https://github.com/team-cymru/network-security-templates/tree/master/Secure-NTP-Templates'>Examples in securing a NTP service</a>
+            <a target='_blank' href='https://christian-rossow.de/publications/amplification-ndss2014.pdf'>Amplification Hell: Revisiting Network Protocols for DDoS Abuse</a>
 
             ",
     ],
@@ -1098,7 +1098,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-2000-server/cc940063(v=technet.10)'>Microsoft NetBIOS Over TCP/IP guide</a>
+            <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-2000-server/cc940063(v=technet.10)'>Microsoft NetBIOS Over TCP/IP guide</a>
 
             ",
     ],
@@ -1251,7 +1251,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://redis.io/docs/latest/operate/oss_and_stack/management/security/'>Redis Security advisory</a><br>
+            <a target='_blank' href='https://redis.io/docs/latest/operate/oss_and_stack/management/security/'>Redis Security advisory</a><br>
 
             ",
     ],
@@ -1474,8 +1474,8 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://web.dev/articles/hacked'>Google's tips voor webmasters van gehackte websites (Engels)</a><br>
-            <a target'_blank' href='https://www.antiphishing.org/'>De site antiphishing.org heeft aanbevelingen over hoe men het beste om kan gaan met gehackte sites (Engels)</a><br>
+            <a target='_blank' href='https://web.dev/articles/hacked'>Google's tips voor webmasters van gehackte websites (Engels)</a><br>
+            <a target='_blank' href='https://www.antiphishing.org/'>De site antiphishing.org heeft aanbevelingen over hoe men het beste om kan gaan met gehackte sites (Engels)</a><br>
 
             ",
     ],
@@ -1515,7 +1515,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='http://www.anti-abuse.org/multi-rbl-check/'>Anti-abuse multi-rbl-check</a><br>
+            <a target='_blank' href='http://www.anti-abuse.org/multi-rbl-check/'>Anti-abuse multi-rbl-check</a><br>
 
             ",
     ],
@@ -1602,7 +1602,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://www.techtarget.com/searchsecurity/definition/spam-trap'>What is a spam trap and how do you avoid them? (Engels)</a><br>
+            <a target='_blank' href='https://www.techtarget.com/searchsecurity/definition/spam-trap'>What is a spam trap and how do you avoid them? (Engels)</a><br>
 
             ",
     ],
@@ -1675,7 +1675,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://disablesslv3.com/'>Disable SSLv3 - a community-powered step-by-step tutorial (Engels)</a><br>
+            <a target='_blank' href='https://disablesslv3.com/'>Disable SSLv3 - a community-powered step-by-step tutorial (Engels)</a><br>
 
             ",
     ],
@@ -1707,7 +1707,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a target'_blank' href='https://wordpress.org/plugins/sucuri-scanner/'>WordPress Security scanner (Sucuri)</a><br>
+            <a target='_blank' href='https://wordpress.org/plugins/sucuri-scanner/'>WordPress Security scanner (Sucuri)</a><br>
 
             ",
     ],
@@ -1743,7 +1743,7 @@ return [
 
             <h2>Meer informatie</h2>
 
-            <a href='https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-cluster.html#preventing-unauthorized-access'>Secure the Elastic Stack (Engels)</a><br>
+            <a target='_blank' href='https://www.elastic.co/guide/en/elasticsearch/reference/current/secure-cluster.html#preventing-unauthorized-access'>Secure the Elastic Stack (Engels)</a><br>
             ",
     ],
 
@@ -1917,8 +1917,8 @@ return [
             is het alleen mogelijk om over de slachtoffers te rapporteren, niet de werkelijk bron van de DDoS.</p>
             
             <p>Voor meer informatie over hoe geamplificeerde DDoS-aanvallen in hun werk gaan, zie deze 
-            <a href='https://christian-rossow.de/articles/Amplification_DDoS.php'>writeup en paper van Christian Rossow</a> 
-            en de <a href='https://www.us-cert.gov/ncas/alerts/TA14-017A'>US-CERT Alert (TA14-017A)</a>.</p>
+            <a target='_blank' href='https://christian-rossow.de/articles/Amplification_DDoS.php'>writeup en paper van Christian Rossow</a> 
+            en de <a target='_blank' href='https://www.us-cert.gov/ncas/alerts/TA14-017A'>US-CERT Alert (TA14-017A)</a>.</p>
             
             <p>Deze rapportage bevat informatie over het aangevallen IP-adres (src_ip) en de port op de honeypot waarmee geprobeerd is uw IP-adres aan te vallen (dst_port).</p>
     


### PR DESCRIPTION
Fixed target'_blank' typos from https://github.com/AbuseIO/AbuseIO/pull/403#issuecomment-2556964737
Also removed links to sissden.eu in both EN and GR, it was not present in NL. The domain appears to have been taken over for unrelated things