### PR TITLE
Fix 500 upon switching locales in AbuseIO self-help

### DIFF
--- a/app/Http/Controllers/LocaleController.php
+++ b/app/Http/Controllers/LocaleController.php
@@ -24,7 +24,7 @@ class LocaleController extends Controller
             'locales' => 'in:en,nl,gr', // List of supported locales
         ];
 
-        $validator = Validator::make(compact("locale"), $rules);
+        $validator = Validator::make(compact('locale'), $rules);
 
         // update the locale setting in the user
         if (!empty($this->auth_user)) {

--- a/app/Http/Controllers/LocaleController.php
+++ b/app/Http/Controllers/LocaleController.php
@@ -24,7 +24,7 @@ class LocaleController extends Controller
             'locales' => 'in:en,nl,gr', // List of supported locales
         ];
 
-        $validator = Validator::make(compact($locale), $rules);
+        $validator = Validator::make(compact("locale"), $rules);
 
         // update the locale setting in the user
         if (!empty($this->auth_user)) {


### PR DESCRIPTION
Currently, the end-user gets a "500 Server Error" when it tries to switch languages/locales in the AbuseIO self-help interface. This PR fixes this, making it possible to switch between languages withous PHP throwing a exception :)